### PR TITLE
Allowing custom clustering and skipping filtering predicted data in spline methods.

### DIFF
--- a/luq/luq.py
+++ b/luq/luq.py
@@ -541,7 +541,8 @@ class LUQ_temporal(LUQ):
             tol,
             min_knots=3,
             max_knots=100,
-            verbose=False):
+            verbose=False,
+            predictions_need_filtering=True):
         """
         Filter observed and predicted time series data so that difference between iterations is within tolerance.
         :param time_start_idx: first time index to filter
@@ -560,6 +561,8 @@ class LUQ_temporal(LUQ):
         :type verbose: bool
         :return: arrays of filtered predictions, filtered observations, and filtered times
         :rtype: :class:`numpy.ndarray`, :class:`numpy.ndarray`, :class:`numpy.ndarray`
+        :param predictions_need_filtering: check if predictions should be filtered
+        :type predictions_need_filtering: bool
         """
 
         # Use _old and _new to compare to tol and determine when to stop adding knots
@@ -569,46 +572,49 @@ class LUQ_temporal(LUQ):
             self.times[time_start_idx],
             self.times[time_end_idx],
             num_filtered_obs)
-        num_predictions = self.predicted_time_series.shape[0]
         num_obs = self.observed_time_series.shape[0]
-        self.filtered_predictions = np.zeros((num_predictions, num_filtered_obs))
         self.filtered_obs = np.zeros((num_obs, num_filtered_obs))
 
-        for idx in range(num_predictions):
-            filtered_predictions_old, error_old, q_pl = linear_c0_spline(times=times, 
-                                                                         data=self.predicted_time_series[idx, time_start_idx:time_end_idx + 1],
-                                                                         num_knots=min_knots,
-                                                                         filtered_times=filtered_times,
-                                                                         verbose=verbose)
-            i = min_knots + 1
-            while i <= max_knots:
-                filtered_predictions_new, error_new, q_pl = linear_c0_spline(times=times, 
-                                                                             data=self.predicted_time_series[idx, time_start_idx:time_end_idx + 1],
-                                                                             num_knots=i,
-                                                                             filtered_times=filtered_times,
-                                                                             spline_old=q_pl,
-                                                                             verbose=verbose)
+        if predictions_need_filtering:
+            num_predictions = self.predicted_time_series.shape[0]
+            self.filtered_predictions = np.zeros((num_predictions, num_filtered_obs))
+            for idx in range(num_predictions):
+                filtered_predictions_old, error_old, q_pl = linear_c0_spline(times=times, 
+                                                                            data=self.predicted_time_series[idx, time_start_idx:time_end_idx + 1],
+                                                                            num_knots=min_knots,
+                                                                            filtered_times=filtered_times,
+                                                                            verbose=verbose)
+                i = min_knots + 1
+                while i <= max_knots:
+                    filtered_predictions_new, error_new, q_pl = linear_c0_spline(times=times, 
+                                                                                data=self.predicted_time_series[idx, time_start_idx:time_end_idx + 1],
+                                                                                num_knots=i,
+                                                                                filtered_times=filtered_times,
+                                                                                spline_old=q_pl,
+                                                                                verbose=verbose)
 
-                # After an _old and a _new is computed (when i>min_knots)
-                print(idx, i, error_new)
-                diff = np.average(np.abs(filtered_predictions_new - filtered_predictions_old)) / \
-                    np.average(np.abs(self.predicted_time_series[idx,
-                                                                 time_start_idx:time_end_idx + 1]))
-                if diff < tol:
-                    break
+                    # After an _old and a _new is computed (when i>min_knots)
+                    print(idx, i, error_new)
+                    diff = np.average(np.abs(filtered_predictions_new - filtered_predictions_old)) / \
+                        np.average(np.abs(self.predicted_time_series[idx,
+                                                                    time_start_idx:time_end_idx + 1]))
+                    if diff < tol:
+                        break
+                    else:
+                        i += 1
+                        if i <= max_knots:
+                            filtered_predictions_old = filtered_predictions_new
+                if i > max_knots:
+                    print("Warning: maximum number of knots reached.")
                 else:
-                    i += 1
-                    if i <= max_knots:
-                        filtered_predictions_old = filtered_predictions_new
-            if i > max_knots:
-                print("Warning: maximum number of knots reached.")
-            else:
-                print(idx, i, "knots being used with error of", error_new)
-            if i > max_knots and error_old < error_new:
-                self.filtered_predictions[idx, :] = filtered_predictions_old
-            else:
-                self.filtered_predictions[idx, :] = filtered_predictions_new
-            self.predict_knots.append(q_pl)
+                    print(idx, i, "knots being used with error of", error_new)
+                if i > max_knots and error_old < error_new:
+                    self.filtered_predictions[idx, :] = filtered_predictions_old
+                else:
+                    self.filtered_predictions[idx, :] = filtered_predictions_new
+                self.predict_knots.append(q_pl)
+        else:
+            self.filtered_predictions = self.predicted_time_series
 
         for idx in range(num_obs):
             filtered_obs_old, error_old, q_pl = linear_c0_spline(times=times,
@@ -656,7 +662,8 @@ class LUQ_temporal(LUQ):
             tol,
             min_knots=3,
             max_knots=100,
-            verbose=False):
+            verbose=False,
+            predictions_need_filtering=True):
         """
         Filter observed and predicted time series data so that the mean l1 error is within a tolerance.
         :param time_start_idx: first time index to filter
@@ -675,6 +682,8 @@ class LUQ_temporal(LUQ):
         :type verbose: bool
         :return: arrays of filtered predictions, filtered observations, and filtered times
         :rtype: :class:`numpy.ndarray`, :class:`numpy.ndarray`, :class:`numpy.ndarray`
+        :param predictions_need_filtering: check if predictions should be filtered
+        :type predictions_need_filtering: bool
         """
 
         i = min_knots
@@ -685,34 +694,37 @@ class LUQ_temporal(LUQ):
             self.times[time_start_idx],
             self.times[time_end_idx],
             num_filtered_obs)
-        num_predictions = self.predicted_time_series.shape[0]
         num_obs = self.observed_time_series.shape[0]
-        self.filtered_predictions = np.zeros((num_predictions, num_filtered_obs))
         self.filtered_obs = np.zeros((num_obs, num_filtered_obs))
 
-        for idx in range(num_predictions):
-            i = min_knots
-            q_pl_old = None
-            while i <= max_knots:
-                filtered_predictions, error, q_pl = linear_c0_spline(times=times, 
-                                                                     data=self.predicted_time_series[idx, time_start_idx:time_end_idx + 1],
-                                                                     num_knots=i,
-                                                                     filtered_times=filtered_times,
-                                                                     spline_old=q_pl_old)
+        if predictions_need_filtering:
+            num_predictions = self.predicted_time_series.shape[0]
+            self.filtered_predictions = np.zeros((num_predictions, num_filtered_obs))
+            for idx in range(num_predictions):
+                i = min_knots
+                q_pl_old = None
+                while i <= max_knots:
+                    filtered_predictions, error, q_pl = linear_c0_spline(times=times, 
+                                                                        data=self.predicted_time_series[idx, time_start_idx:time_end_idx + 1],
+                                                                        num_knots=i,
+                                                                        filtered_times=filtered_times,
+                                                                        spline_old=q_pl_old)
 
-                # After an _old and a _new is computed (when i>min_knots)
-                print(idx, i, error)
-                if error <= tol:
-                    break
+                    # After an _old and a _new is computed (when i>min_knots)
+                    print(idx, i, error)
+                    if error <= tol:
+                        break
+                    else:
+                        i += 1
+                        q_pl_old = q_pl
+                        # and _old = _new
+                if i > max_knots:
+                    print("Warning: maximum number of knots reached.")
                 else:
-                    i += 1
-                    q_pl_old = q_pl
-                    # and _old = _new
-            if i > max_knots:
-                print("Warning: maximum number of knots reached.")
-            else:
-                print(idx, i, "knots being used")
-            self.filtered_predictions[idx, :] = filtered_predictions
+                    print(idx, i, "knots being used")
+                self.filtered_predictions[idx, :] = filtered_predictions
+        else:
+            self.filtered_predictions = self.predicted_time_series
 
         for idx in range(num_obs):
             i = min_knots
@@ -752,8 +764,7 @@ class LUQ_spatial(LUQ):
                  predicted_data, 
                  observed_data,
                  predicted_data_coordinates,
-                 observed_data_coordinates=None,
-                 predictions_need_filtering=False):
+                 observed_data_coordinates=None):
         '''
         :param predicted_data: predicted spatial data at predicted_data_coordinates
         :type predicted_data: :class:'numpy.ndarray'
@@ -772,7 +783,6 @@ class LUQ_spatial(LUQ):
             self.observed_data_coordinates = predicted_data_coordinates
         else:
             self.observed_data_coordinates = observed_data_coordinates
-        self.predictions_need_filtering = predictions_need_filtering
 
     def filter_data(self,
                    num_rbf_list,
@@ -781,9 +791,10 @@ class LUQ_spatial(LUQ):
                    poly_deg=None,
                    initializer='Halton',
                    max_opt_count=3,
-                   tol=1e-4):
+                   tol=1e-4,
+                   predictions_need_filtering=True):
         
-        if self.predictions_need_filtering:
+        if predictions_need_filtering:
             fit_pred = RBFFit(self.predicted_data_coordinates, 
                               self.predicted_data_coordinates,
                               remove_trend,


### PR DESCRIPTION
First commit adjusts methods that perform clustering to allow custom clustering by user and adjusts the SVM method to relabel predicted data as default but allows user to keep custom clustering labels if desired. Second commit adds option of filtering only observed data in LUQ_temporal instead of both observed and predicted data - still defaults to filtering both.