### PR TITLE
specifying trust region method for least squares solve

### DIFF
--- a/luq/rbf_fit.py
+++ b/luq/rbf_fit.py
@@ -517,7 +517,8 @@ class RBFFit(object):
                                     output_data_shifted,
                                     p0=p0,
                                     bounds=param_bounds,
-                                    max_nfev=max_nfev)
+                                    max_nfev=max_nfev,
+                                    method='trf')
 
             # unpacking fitted parameters
             if self.add_poly:


### PR DESCRIPTION
Specified trust region method for least squares solve. If not specified, scipy.optimize.curve_fit sometimes uses least squares module from scipy.linalg which does not recognize max_nfev.